### PR TITLE
Increase minimum python version to 3.8 and bump zod version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zod"
-version = "0.4.0"
+version = "0.5.0"
 description = "Zenseact Open Dataset"
 authors = ["Zenseact <opendataset@zenseact.com>"]
 license = "MIT"
@@ -12,7 +12,7 @@ repository = "https://github.com/zenseact/zod"
 zod = "zod.cli.main:app"
 
 [tool.poetry.dependencies]
-python = "^3.7.1"
+python = "^3.8"
 tqdm = ">=4.60"
 numpy = "^1.19"
 scipy = "^1.5"
@@ -21,15 +21,13 @@ h5py = ">=3.1"
 pyquaternion = ">=0.9"
 numpy-quaternion = ">=2022.4.2"
 dataclass-wizard = ">=0.22.2"
-importlib-metadata = { version = "*", python = "<3.8" }
-typing-extensions = { version = "*", python = "<3.8" }
 # Optional dependencies
 typer = { extras = ["all"], version = ">=0.7.0", optional = true }
 dropbox = { version = ">=11.36.0", optional = true }
-opencv-python = { version = ">=4", optional = true }
-matplotlib = { version = ">=3", optional = true }
+opencv-python = { version = "^4", optional = true }
+matplotlib = { version = "^3", optional = true }
 plotly = { version = "^5", optional = true }
-dash-bootstrap-components = { version = ">=1.1", optional = true }
+dash-bootstrap-components = { version = "^1.1", optional = true }
 pandas = { version = "^1.3", optional = true }
 notebook = { version = ">=5", optional = true }
 imageio = { version = "^2", optional = true }

--- a/zod/__init__.py
+++ b/zod/__init__.py
@@ -1,5 +1,7 @@
 """Top-level package for Zenseact Open Dataset (ZOD)."""
 
+import importlib.metadata as importlib_metadata
+
 from ._zod_dataset import ZodDataset as ZodDataset  # For type hinting
 from .anno.ego_road import EgoRoadAnnotation as EgoRoadAnnotation
 from .anno.lane import LaneAnnotation as LaneAnnotation
@@ -15,13 +17,6 @@ from .data_classes.sequence import ZodSequence as ZodSequence
 from .zod_drives import ZodDrives as ZodDrives
 from .zod_frames import ZodFrames as ZodFrames
 from .zod_sequences import ZodSequences as ZodSequences
-
-try:
-    # importlib.metadata is present in Python 3.8 and later
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # use the shim package importlib-metadata pre-3.8
-    import importlib_metadata as importlib_metadata
 
 try:
     __version__ = importlib_metadata.version(__package__ or __name__)

--- a/zod/constants.py
+++ b/zod/constants.py
@@ -2,13 +2,7 @@
 
 import typing
 from enum import Enum
-from typing import Union
-
-# Python 3.7 compatibility
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+from typing import Literal, Union
 
 # Dataset paths
 FRAMES = "single_frames"


### PR DESCRIPTION
Python 3.7 has reached end of life last summer, and resolving dependencies has become a nightmare for that version.

Therefore:
- bump minimum python version to 3.8
- specify some other versions a bit more strictly
- remove some legacy import checks for python 3.7
- bump zod version to 0.5