### PR TITLE
Add radar support

### DIFF
--- a/zod/constants.py
+++ b/zod/constants.py
@@ -95,9 +95,13 @@ class Lidar(Enum):
     VELODYNE = "velodyne"
 
 
+class Radar(Enum):
+    FRONT = "front"
+
+
 Ego = Literal["ego"]
 EGO = typing.get_args(Ego)[0]
-CoordinateFrame = Union[Camera, Lidar, Ego]
+CoordinateFrame = Union[Camera, Lidar, Radar, Ego]
 
 
 # ZodFrame properties

--- a/zod/data_classes/info.py
+++ b/zod/data_classes/info.py
@@ -5,10 +5,10 @@ from itertools import chain
 from typing import Dict, Iterator, List, Optional, Tuple
 
 from zod.anno.parser import AnnotationFile
-from zod.constants import AnnotationProject, Anonymization, Camera, Lidar
+from zod.constants import AnnotationProject, Anonymization, Camera, Lidar, Radar
 
 from ._serializable import JSONSerializable
-from .sensor import CameraFrame, LidarFrame, SensorFrame
+from .sensor import CameraFrame, LidarFrame, RadarFrames, SensorFrame
 
 
 @dataclass
@@ -29,6 +29,7 @@ class Information(JSONSerializable):
     annotations: Dict[AnnotationProject, AnnotationFile]
     camera_frames: Dict[str, List[CameraFrame]]  # key is a combination of Camera and Anonymization
     lidar_frames: Dict[Lidar, List[LidarFrame]]
+    radar_frames: Dict[Radar, RadarFrames]
 
     @property
     def all_frames(self) -> Iterator[SensorFrame]:
@@ -130,3 +131,6 @@ class Information(JSONSerializable):
 
     def get_lidar_frames(self, lidar: Lidar = Lidar.VELODYNE) -> List[LidarFrame]:
         return self.lidar_frames[lidar]
+
+    def get_radar_frames(self, radar: Radar) -> RadarFrames:
+        return self.radar_frames[radar]

--- a/zod/data_classes/sensor.py
+++ b/zod/data_classes/sensor.py
@@ -305,6 +305,18 @@ class LidarFrame(SensorFrame):
 
 
 @dataclass
+class RadarFrames(JSONSerializable):
+    """Class to store information about a radar sequence file."""
+
+    filepath: str
+    time: datetime # time of the sequence key frame
+
+    def read(self) -> RadarData:
+        """Read the radar data."""
+        return RadarData.from_npy(self.filepath)
+
+
+@dataclass
 class CameraFrame(SensorFrame):
     """Class to store information about a camera frame."""
 


### PR DESCRIPTION
In this change I'm adding a data class for the radar data. This class is mostly similar to LidarData except that instead of a single radar frame it includes radar data for the entire sequence. It reads from and writes to a radar .npy file, and right now I mostly need it to upload the radar data for sequences and drives to dropbox. Each file includes the following information:
- radar range
- azimuth angle
- elevation angle
- range rate (detection velocity relative to the radar sensor)
- amplitude (signal to noise ratio / SNR)
- validity (detection validity 0 or 1)
- mode (radar mode, can be 0, 1, and 2, depends on ego speed and changes the FOV.)
- quality (detection quality, can be 0:low, 1: medium, and 2: high.)
- scan index (which radar frame the detection comes from)
- timestamp (in nanoseconds)