### PR TITLE
Add radar support

### DIFF
--- a/zod/constants.py
+++ b/zod/constants.py
@@ -95,9 +95,13 @@ class Lidar(Enum):
     VELODYNE = "velodyne"
 
 
+class Radar(Enum):
+    FRONT = "front"
+
+
 Ego = Literal["ego"]
 EGO = typing.get_args(Ego)[0]
-CoordinateFrame = Union[Camera, Lidar, Ego]
+CoordinateFrame = Union[Camera, Lidar, Radar, Ego]
 
 
 # ZodFrame properties

--- a/zod/data_classes/info.py
+++ b/zod/data_classes/info.py
@@ -29,7 +29,7 @@ class Information(JSONSerializable):
     annotations: Dict[AnnotationProject, AnnotationFile]
     camera_frames: Dict[str, List[CameraFrame]]  # key is a combination of Camera and Anonymization
     lidar_frames: Dict[Lidar, List[LidarFrame]]
-    radar_frames: Dict[Radar, RadarFrames]
+    radar_frames: Optional[Dict[Radar, List[RadarFrames]]] = None
 
     @property
     def all_frames(self) -> Iterator[SensorFrame]:
@@ -133,4 +133,6 @@ class Information(JSONSerializable):
         return self.lidar_frames[lidar]
 
     def get_radar_frames(self, radar: Radar) -> RadarFrames:
+        if self.radar_frames is None:
+            raise ValueError("No radar frames available.")
         return self.radar_frames[radar]

--- a/zod/data_classes/info.py
+++ b/zod/data_classes/info.py
@@ -134,5 +134,7 @@ class Information(JSONSerializable):
 
     def get_radar_frames(self, radar: Radar) -> RadarFrames:
         if self.radar_frames is None:
-            raise ValueError("No radar frames available.\nPlease download the latest version of ZOD to access radar data. Radar is available for ZOD Sequences and Drives only.")
+            raise ValueError(
+                "No radar frames available.\nPlease download the latest version of ZOD to access radar data. Radar is available for ZOD Sequences and Drives only."
+            )
         return self.radar_frames[radar]

--- a/zod/data_classes/info.py
+++ b/zod/data_classes/info.py
@@ -134,7 +134,8 @@ class Information(JSONSerializable):
 
     def get_radar_frames(self, radar: Radar) -> RadarFrames:
         if self.radar_frames is None:
-            raise ValueError(
-                "No radar frames available.\nPlease download the latest version of ZOD to access radar data. Radar is available for ZOD Sequences and Drives only."
-            )
+            err = "No radar frames available!"
+            err += "\nPlease download the latest version of ZOD to access radar data. "
+            err += "\nRadar is available for ZOD Sequences and Drives only."
+            raise ValueError(err)
         return self.radar_frames[radar]

--- a/zod/data_classes/info.py
+++ b/zod/data_classes/info.py
@@ -134,5 +134,5 @@ class Information(JSONSerializable):
 
     def get_radar_frames(self, radar: Radar) -> RadarFrames:
         if self.radar_frames is None:
-            raise ValueError("No radar frames available.")
+            raise ValueError("No radar frames available.\nPlease download the latest version of ZOD to access radar data. Radar is available for ZOD Sequences and Drives only.")
         return self.radar_frames[radar]

--- a/zod/data_classes/info.py
+++ b/zod/data_classes/info.py
@@ -5,10 +5,10 @@ from itertools import chain
 from typing import Dict, Iterator, List, Optional, Tuple
 
 from zod.anno.parser import AnnotationFile
-from zod.constants import AnnotationProject, Anonymization, Camera, Lidar
+from zod.constants import AnnotationProject, Anonymization, Camera, Lidar, Radar
 
 from ._serializable import JSONSerializable
-from .sensor import CameraFrame, LidarFrame, SensorFrame
+from .sensor import CameraFrame, LidarFrame, RadarFrames, SensorFrame
 
 
 @dataclass
@@ -29,6 +29,7 @@ class Information(JSONSerializable):
     annotations: Dict[AnnotationProject, AnnotationFile]
     camera_frames: Dict[str, List[CameraFrame]]  # key is a combination of Camera and Anonymization
     lidar_frames: Dict[Lidar, List[LidarFrame]]
+    radar_frames: Dict[Radar, RadarFrames]
 
     @property
     def all_frames(self) -> Iterator[SensorFrame]:
@@ -130,3 +131,6 @@ class Information(JSONSerializable):
 
     def get_lidar_frames(self, lidar: Lidar = Lidar.VELODYNE) -> List[LidarFrame]:
         return self.lidar_frames[lidar]
+
+    def get_radar_frames(self, radar: Radar) -> RadarFrames:
+        return self.radar_frames[radar]

--- a/zod/data_classes/sensor.py
+++ b/zod/data_classes/sensor.py
@@ -305,6 +305,18 @@ class LidarFrame(SensorFrame):
 
 
 @dataclass
+class RadarFrames(JSONSerializable):
+    """Class to store information about a radar sequence file."""
+
+    filepath: str
+    time: datetime # time of the sequence key frame
+
+    def read(self) -> RadarData:
+        """Read the radar data."""
+        return RadarData.from_npy(self.filepath)
+
+
+@dataclass
 class CameraFrame(SensorFrame):
     """Class to store information about a camera frame."""
 

--- a/zod/data_classes/sensor.py
+++ b/zod/data_classes/sensor.py
@@ -219,22 +219,22 @@ class RadarData:
             ],
         )
 
-        data["radar_range"]=self.radar_range
-        data["azimuth_angle"]=self.azimuth_angle
-        data["elevation_angle"]=self.elevation_angle
-        data["range_rate"]=self.range_rate
-        data["amplitude"]=self.amplitude
-        data["validity"]=self.validity
-        data["mode"]=self.mode
-        data["quality"]=self.quality
-        data["scan_index"]=self.scan_index
+        data["radar_range"] = self.radar_range
+        data["azimuth_angle"] = self.azimuth_angle
+        data["elevation_angle"] = self.elevation_angle
+        data["range_rate"] = self.range_rate
+        data["amplitude"] = self.amplitude
+        data["validity"] = self.validity
+        data["mode"] = self.mode
+        data["quality"] = self.quality
+        data["scan_index"] = self.scan_index
         if len(self.timestamp) == 1:
-            data["timestamp"]=self.timestamp
+            data["timestamp"] = self.timestamp
         else:
             times = np.empty(len(self.radar_range), dtype=np.int64)
             for i in range(len(self.timestamp)):
-                times[self.scan_index==i] = self.timestamp[i]
-            data["timestamp"]=times
+                times[self.scan_index == i] = self.timestamp[i]
+            data["timestamp"] = times
 
         np.save(path, data)
 
@@ -309,7 +309,7 @@ class RadarFrames(JSONSerializable):
     """Class to store information about a radar sequence file."""
 
     filepath: str
-    time: datetime # time of the sequence key frame
+    time: datetime  # time of the sequence key frame
 
     def read(self) -> RadarData:
         """Read the radar data."""


### PR DESCRIPTION
In this change I'm adding a data class for the radar data. This class is mostly similar to LidarData except that instead of a single radar frame it includes radar data for the entire sequence. It reads from and writes to a radar .npy file, and right now I mostly need it to upload the radar data for sequences and drives to dropbox. Each file includes the following information:

- radar range
- azimuth angle
- elevation angle
- range rate (detection velocity relative to the radar sensor)
- amplitude (signal to noise ratio / SNR)
- validity (detection validity 0 or 1)
- mode (radar mode, can be 0, 1, and 2, depends on ego speed and changes the FOV.)
- quality (detection quality, can be 0:low, 1: medium, and 2: high.)
- scan index (which radar frame the detection comes from)
- timestamp (in nanoseconds)