### PR TITLE
Fix mutable default <class 'numpy.ndarray'> for field grid_min is not allowed: use default_factory

### DIFF
--- a/zod/visualization/bev_utils.py
+++ b/zod/visualization/bev_utils.py
@@ -1,6 +1,6 @@
 """Utilities for creating point cloud input representation."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Tuple
 
 import numpy as np
@@ -25,8 +25,8 @@ class BEVSettings:
 
     # pylint: disable=too-many-instance-attributes
     # General settings
-    grid_min: np.ndarray = np.array([-50.0, 0.0])
-    grid_max: np.ndarray = np.array([50.0, 100.0])
+    grid_min: np.ndarray = field(default_factory=lambda: np.array([-50.0, 0.0]))
+    grid_max: np.ndarray = field(default_factory=lambda: np.array([50.0, 100.0]))
     grid_cell_size: float = 0.1  # Default in PIXOR: 0.1
 
     # Pixor settings
@@ -94,7 +94,7 @@ def _create_pointcloud_input_pixor(
         A PIXOR style BEV projection of the input point cloud.
 
     """
-    point_indices_c = np.cast["int32"]((points[:, 2] - settings.pixor_z_min) / settings.grid_cell_size)
+    point_indices_c = np.asarray((points[:, 2] - settings.pixor_z_min) / settings.grid_cell_size, dtype="int32")
     point_indices_c = 1 + np.clip(
         point_indices_c,
         a_min=-1,
@@ -156,7 +156,7 @@ def get_grid_indices_xy(cloud: np.ndarray, settings: BEVSettings) -> np.ndarray:
 
     """
     # Convert points to indices
-    indices_xy = np.cast["int32"]((cloud[:, :2] - settings.grid_min) / settings.grid_cell_size)
+    indices_xy = np.asarray((cloud[:, :2] - settings.grid_min) / settings.grid_cell_size, dtype="int32")
     return indices_xy
 
 

--- a/zod/visualization/lidar_bev.py
+++ b/zod/visualization/lidar_bev.py
@@ -122,7 +122,7 @@ class BEVBox:
         )
 
         # Add arrow in the direction of the object
-        arrow_length = int(np.cast["float32"](dimension[0]) * 0.8)
+        arrow_length = int(np.asarray(dimension[0]) * 0.8, dtype="float32")
         end_point = np.array([arrow_length, 0, 0])
         end_point = rotation.rotate(end_point)[:2] + position
         fig.add_annotation(
@@ -156,6 +156,6 @@ class BEVBox:
     @staticmethod
     def _create_od_vis_background(input_array: np.ndarray) -> np.ndarray:
         """Create a gray occupancy grid as background to visualize over."""
-        occupancy = np.maximum.reduce(np.cast["float32"](np.abs(input_array) > 0.0), axis=0, keepdims=True)
+        occupancy = np.maximum.reduce(np.asarray(np.abs(input_array) > 0.0, dtype="float32"), axis=0, keepdims=True)
         vis_bg = np.transpose(np.repeat(occupancy * 77, 3, axis=0), [2, 1, 0])
         return vis_bg


### PR DESCRIPTION
For users of Numpy 2.x the np.cast functions are deprecated, also to use mutable default (e.g. a np.ndarray) directly as default value for a field in a @DataClass can't be done.

https://github.com/zenseact/zod/issues/69