### PR TITLE
Changing JSONSerializable to JSONWizard

### DIFF
--- a/zod/data_classes/_serializable.py
+++ b/zod/data_classes/_serializable.py
@@ -1,6 +1,6 @@
 import json
 
-from dataclass_wizard import JSONSerializable as _JSONSerializable
+from dataclass_wizard import JSONWizard as _JSONSerializable
 
 
 class JSONSerializable(_JSONSerializable):


### PR DESCRIPTION
`JSONSerializable` was officially removed as an alias in version 1.0.0 of [dataclass-wizard](https://github.com/rnag/dataclass-wizard), released on July 2, 2026, and the installation of the ZOD CLI via pip installs the latest version of dataclass-wizard, which results in the error:
`ImportError: cannot import name 'JSONSerializable' from 'dataclass_wizard'. `

Currently, `JSONWizard` should be used instead as the base mixin class. 
In this PR `JSONSerializable` is replaced by `JSONWizard` in `/zod/zod/data_classes/_serializable.py`