### PR TITLE
Replacing typer[all] by typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,12 @@ dependencies = [
 
 [project.optional-dependencies]
 cli = [
-    "typer[all]>=0.15.0",
+    "typer>=0.15.0",
     "dropbox>=11.36.0",
     "click>=8.4.0",
 ]
 all = [
-    "typer[all]>=0.15.0",
+    "typer>=0.15.0",
     "dropbox>=11.36.0",
     "click>=8.4.0",
     "opencv-python>=4,<5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,12 @@ dependencies = [
 cli = [
     "typer[all]>=0.15.0",
     "dropbox>=11.36.0",
+    "click>=8.4.0",
 ]
 all = [
     "typer[all]>=0.15.0",
     "dropbox>=11.36.0",
+    "click>=8.4.0",
     "opencv-python>=4,<5",
     "matplotlib>=3,<4",
     "plotly>=5,<6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ all = [
     "matplotlib>=3,<4",
     "plotly>=5,<6",
     "dash-bootstrap-components~=1.1",
-    "pandas~=1.3",
+    "pandas>=1.3",
     "notebook>=5",
     "imageio>=2,<3",
 ]

--- a/zod/data_classes/_serializable.py
+++ b/zod/data_classes/_serializable.py
@@ -1,6 +1,6 @@
 import json
 
-from dataclass_wizard import JSONSerializable as _JSONSerializable
+from dataclass_wizard import JSONWizard as _JSONSerializable
 
 
 class JSONSerializable(_JSONSerializable):


### PR DESCRIPTION
Replacing `typer[all]>=0.15.0` by `typer>=0.15.0` as `typer` no longer has an extra named `all` and everything previously included in `typer[all]` is now included in `typer`.